### PR TITLE
fix: remove componentWillReceiveProps

### DIFF
--- a/lib/radioButton.js
+++ b/lib/radioButton.js
@@ -3,19 +3,20 @@ import PropTypes from 'prop-types'
 import {
   StyleSheet,
   View,
-  Text,
   TouchableWithoutFeedback
 } from 'react-native';
 
 export default class RadioButton extends Component{
     constructor(props, context){
         super(props, context)
+
+        this.state = { selectedIndex: 0 }
     }
 
-    componentWillReceiveProps(nextProps){
-		this.setState({
+    static getDerivedStateFromProps(nextProps){
+		return {
 			selectedIndex: nextProps.selectedIndex
-		})
+		}
 	}
 
     getRadioStyle(){
@@ -87,3 +88,4 @@ let styles = StyleSheet.create({
 	justifyContent: 'center',
   }
 })
+

--- a/lib/radioGroup.js
+++ b/lib/radioGroup.js
@@ -23,13 +23,15 @@ export default  class RadioGroup extends Component{
         this.onSelect = this.onSelect.bind(this)
     }
 
-    componentWillReceiveProps(nextProps){
+    static getDerivedStateFromProps(nextProps){
         if(nextProps.selectedIndex != this.prevSelected){
             this.prevSelected = nextProps.selectedIndex
-            this.setState({
+            return {
                 selectedIndex: nextProps.selectedIndex
-            })
+            }
         }
+
+        return null
 	}
 
     getChildContext() {


### PR DESCRIPTION
The lifecycle componentWillReceiveProps is deprecated as React 16 and
will stop working in React 17.

As stated in the react blog [1] the definitive solution is to migrate
this lifecycle to getDerivedStateFromProps.

[1] https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html